### PR TITLE
Update to https endpoint

### DIFF
--- a/library/Pintlabs/Service/Untappd.php
+++ b/library/Pintlabs/Service/Untappd.php
@@ -13,7 +13,7 @@ class Pintlabs_Service_Untappd
      *
      * @var string
      */
-    const URI_BASE = 'http://api.untappd.com/v4';
+    const URI_BASE = 'https://api.untappd.com/v4';
 
     /**
      * Client ID


### PR DESCRIPTION
As an Untappd API developer, we wanted to inform you that you will need to update your application to use our secure, HTTPS API endpoint (https://api.untappd.com). We will be discontinuing our standard HTTP API endpoint on 2/1/15. This will require you to update your code for your application to change the http:// protocol to https://.